### PR TITLE
feat: MYSUM の代わりに MYAVG を実装

### DIFF
--- a/my_extension/Cargo.toml
+++ b/my_extension/Cargo.toml
@@ -17,6 +17,7 @@ pg_test = []
 [dependencies]
 pgx = "0.1.21"
 pgx-macros = "0.1.21"
+serde = {version = "1.0", features = ["derive"]}
 
 [dev-dependencies]
 pgx-tests = "0.1.21"


### PR DESCRIPTION
```bash
 cargo pgx run pg13
```

```sql
my_extension=# DROP EXTENSION my_extension; CREATE EXTENSION my_extension;
DROP EXTENSION
CREATE EXTENSION
my_extension=# create table t (c integer);
CREATE TABLE
my_extension=# insert into t (c) values (1), (2), (3);
INSERT 0 3
my_extension=# select * from t;
 c
---
 1
 2
 3
(3 rows)

my_extension=# select MYAVG(c) from t;
 myavg
-------
     2
(1 row)
```